### PR TITLE
fix: gitignore dist/, github api auth, cache busting css

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -115,6 +115,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Inject CSS cache-busting query param
+        run: |
+          SHA=$(git rev-parse --short HEAD)
+          sed -i "s|href=\"dist/output.css\"|href=\"dist/output.css?v=${SHA}\"|g" index.html
+          echo "CSS cache-busting param: ?v=${SHA}"
+
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 node_modules/
-dist/output.css
+dist/

--- a/scripts/update_downloads.py
+++ b/scripts/update_downloads.py
@@ -191,7 +191,7 @@ def git_commit_push(token: str = None) -> bool:
 
 
 def main() -> None:
-    token = os.environ.get("GITHUB_TOKEN")
+    token = os.environ.get("GITHUB_TOKEN", "")
     repo_list = load_repos_list()
     print(f"Counting downloads for owner: {OWNER}")
     if repo_list:


### PR DESCRIPTION
## Изменения
- dist/ добавлен в .gitignore
- update_downloads.py: строгий тип для GITHUB_TOKEN
- deploy.yml: CSS href получает ?v=<git-sha> при каждом деплое